### PR TITLE
Changed mount point in examples to /app (/opt being already used by yarn)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -20,14 +20,14 @@ This image has the same usage as Angular CLI (https://cli.angular.io/)
 Creating a project
 ==================
 
-`docker run -it --rm -w /opt -v $(pwd):/opt alexsuch/angular-cli ng new my-project-name`
+`docker run -it --rm -w /app -v $(pwd):/app alexsuch/angular-cli ng new my-project-name`
 
 Generating a component
 ======================
 
-`docker run -it --rm -w /opt -v $(pwd):/opt alexsuch/angular-cli ng g component sample-component`
+`docker run -it --rm -w /app -v $(pwd)/my-project-name:/app alexsuch/angular-cli ng g component sample-component`
 
 Serving
 =======
 
-`docker run -it --rm -w /opt -v $(pwd):/opt -p 4200:4200 alexsuch/angular-cli ng serve --host 0.0.0.0`
+`docker run -it --rm -w /app -v $(pwd)/my-project-name:/app -p 4200:4200 alexsuch/angular-cli ng serve --host 0.0.0.0`


### PR DESCRIPTION
I think yarn installation is missing