### PR TITLE
angular-cli:1.2.1, fixed node on version 6.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:6-alpine
+FROM node:6.11.1-alpine
 
 LABEL authors="Alejandro Such <alejandro.such@gmail.com> , Mihai Bob <mihai.m.bob@gmail.com>"
 
 RUN apk update \
   && apk add --update alpine-sdk \
-  && npm install -g @angular/cli@1.2.0 \
+  && npm install -g @angular/cli@1.2.1 \
   && ng set --global packageManager=yarn \
   && apk del alpine-sdk \
   && rm -rf /tmp/* /var/cache/apk/* *.tar.gz ~/.npm \

--- a/README.txt
+++ b/README.txt
@@ -4,10 +4,10 @@
  / ___ \| | | | (_| | |_| | | (_| | |      | |___| |___ | |
 /_/   \_\_| |_|\__, |\__,_|_|\__,_|_|       \____|_____|___|
                |___/
-@angular/cli: 1.2.0
-node: 6.10.2
+@angular/cli: 1.2.1
+node: 6.11.1
 npm: 3.10.10
-yarn: 0.23.2
+yarn: 0.24.6
 os: linux x64
 package manager: yarn
 docker hub: https://hub.docker.com/r/alexsuch/angular-cli/


### PR DESCRIPTION
fixed node on version 6.11.1 for better repeatability and provenance

using 6-alpine will include 6.11 nowadays and the readme said it includes 6.10