### PR TITLE
Add procps so we can use a more featureful ps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:9.2.0-alpine
 LABEL authors="Alejandro Such <alejandro.such@gmail.com> , Mihai Bob <mihai.m.bob@gmail.com>"
 
 RUN apk update \
-  && apk add --update alpine-sdk python \
+  && apk add --update alpine-sdk python procps \
   && yarn global add @angular/cli@1.5.5 \
   && ng set --global packageManager=yarn \
   && apk del alpine-sdk python \


### PR DESCRIPTION
I'm using this image in a CI environment which does checking of processes running my passing `-p` to `ps` which isn't supported in the BusyBox `ps`. It would be nice to get this upstream so I don't have to build my own image. But if you don't want to accept just close and I'll fork to build my own Angular CLI image.